### PR TITLE
Allow link paths to be specified by downstream packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@ It is quite possible to use this crate directly from your rust code, but it will
 
 Instead it is recommended that you use the safe wrapper of this ffi interface.
 https://crates.io/crates/cassandra
+
+## Compilation
+
+By default, `/usr/lib`, `/usr/local/lib64`, and `/usr/local/lib` are added to the linker search path.
+
+A semicolon separated list of additional directories to add to the linker search path may be specified through the `CASSANDRA_SYS_LIB_PATH` environment variable.

--- a/build.rs
+++ b/build.rs
@@ -15,6 +15,11 @@
 //use std::process::Command;
 
 fn main() {
+    if let Some(datastax_dir) = option_env!("CASSANDRA_SYS_LIB_PATH") {
+        for p in datastax_dir.split(";") {
+            println!("cargo:rustc-link-search={}", p);
+        }
+    }
     println!("cargo:rustc-flags=-l dylib=crypto");
     println!("cargo:rustc-flags=-l dylib=ssl");
     println!("cargo:rustc-flags=-l dylib=stdc++");


### PR DESCRIPTION
This commit changes the build script to allow an environment variable to control the paths that are searched when linking. This allows a downstream package to use libraries like the the DataStax driver that are not installed in /usr/lib or /usr/local/lib64. 

The previous behavior of adding /usr/lib and /usr/local/lib64 to the search path is retained if the environment variable is not set. 
