### PR TITLE
order ld includes by most-specific first, adding /usr/lib64/

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -24,8 +24,9 @@ fn main() {
     println!("cargo:rustc-flags=-l dylib=ssl");
     println!("cargo:rustc-flags=-l dylib=stdc++");
     println!("cargo:rustc-flags=-l dylib=uv");
-    println!("cargo:rustc-link-search={}", "/usr/lib/");
     println!("cargo:rustc-link-search={}", "/usr/local/lib64");
     println!("cargo:rustc-link-search={}", "/usr/local/lib");
+    println!("cargo:rustc-link-search={}", "/usr/lib64/");
+    println!("cargo:rustc-link-search={}", "/usr/lib/");
     println!("cargo:rustc-link-lib=static=cassandra_static");
 }


### PR DESCRIPTION
This was required to resolve linking issues on Centos7, with locally-compiled libuv and the installed path of the cassandra-cpp driver libs.
