### PR TITLE
Get library build working on stable.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -80,151 +80,181 @@ impl fmt::Display for CassError_ {
 
 impl CassError_ {
     pub fn to_result<T>(self, t: T) -> Result<T> {
-        use self::CassError_::*;
         match self {
-            CASS_OK => Ok(t),
-            CASS_ERROR_LIB_BAD_PARAMS => Err(ErrorKind::LIB_BAD_PARAMS(CASS_ERROR_LIB_BAD_PARAMS).into()),
-            CASS_ERROR_LIB_NO_STREAMS => Err(ErrorKind::LIB_NO_STREAMS(CASS_ERROR_LIB_NO_STREAMS).into()),
-            CASS_ERROR_LIB_UNABLE_TO_INIT => Err(ErrorKind::LIB_UNABLE_TO_INIT(CASS_ERROR_LIB_UNABLE_TO_INIT).into()),
-            CASS_ERROR_LIB_MESSAGE_ENCODE => Err(ErrorKind::LIB_MESSAGE_ENCODE(CASS_ERROR_LIB_MESSAGE_ENCODE).into()),
-            CASS_ERROR_LIB_HOST_RESOLUTION => {
-                Err(ErrorKind::LIB_HOST_RESOLUTION(CASS_ERROR_LIB_HOST_RESOLUTION).into())
+            CassError_::CASS_OK => Ok(t),
+            CassError_::CASS_ERROR_LIB_BAD_PARAMS => {
+                Err(ErrorKind::LIB_BAD_PARAMS(CassError_::CASS_ERROR_LIB_BAD_PARAMS).into())
             }
-            CASS_ERROR_LIB_UNEXPECTED_RESPONSE => {
-                Err(ErrorKind::LIB_UNEXPECTED_RESPONSE(CASS_ERROR_LIB_UNEXPECTED_RESPONSE).into())
+            CassError_::CASS_ERROR_LIB_NO_STREAMS => {
+                Err(ErrorKind::LIB_NO_STREAMS(CassError_::CASS_ERROR_LIB_NO_STREAMS).into())
             }
-            CASS_ERROR_LIB_REQUEST_QUEUE_FULL => {
-                Err(ErrorKind::LIB_REQUEST_QUEUE_FULL(CASS_ERROR_LIB_UNEXPECTED_RESPONSE).into())
+            CassError_::CASS_ERROR_LIB_UNABLE_TO_INIT => {
+                Err(ErrorKind::LIB_UNABLE_TO_INIT(CassError_::CASS_ERROR_LIB_UNABLE_TO_INIT).into())
             }
-            CASS_ERROR_LIB_NO_AVAILABLE_IO_THREAD => {
-                Err(ErrorKind::LIB_NO_AVAILABLE_IO_THREAD(CASS_ERROR_LIB_NO_AVAILABLE_IO_THREAD).into())
+            CassError_::CASS_ERROR_LIB_MESSAGE_ENCODE => {
+                Err(ErrorKind::LIB_MESSAGE_ENCODE(CassError_::CASS_ERROR_LIB_MESSAGE_ENCODE).into())
             }
-            CASS_ERROR_LIB_WRITE_ERROR => Err(ErrorKind::LIB_WRITE_ERROR(CASS_ERROR_LIB_WRITE_ERROR).into()),
-            CASS_ERROR_LIB_NO_HOSTS_AVAILABLE => {
-                Err(ErrorKind::LIB_NO_HOSTS_AVAILABLE(CASS_ERROR_LIB_NO_HOSTS_AVAILABLE).into())
+            CassError_::CASS_ERROR_LIB_HOST_RESOLUTION => {
+                Err(ErrorKind::LIB_HOST_RESOLUTION(CassError_::CASS_ERROR_LIB_HOST_RESOLUTION).into())
             }
-            CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS => {
-                Err(ErrorKind::LIB_INDEX_OUT_OF_BOUNDS(CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS).into())
+            CassError_::CASS_ERROR_LIB_UNEXPECTED_RESPONSE => {
+                Err(ErrorKind::LIB_UNEXPECTED_RESPONSE(CassError_::CASS_ERROR_LIB_UNEXPECTED_RESPONSE).into())
             }
-            CASS_ERROR_LIB_INVALID_ITEM_COUNT => {
-                Err(ErrorKind::LIB_INVALID_ITEM_COUNT(CASS_ERROR_LIB_INVALID_ITEM_COUNT).into())
+            CassError_::CASS_ERROR_LIB_REQUEST_QUEUE_FULL => {
+                Err(ErrorKind::LIB_REQUEST_QUEUE_FULL(CassError_::CASS_ERROR_LIB_UNEXPECTED_RESPONSE).into())
             }
-            CASS_ERROR_LIB_INVALID_VALUE_TYPE => {
-                Err(ErrorKind::LIB_INVALID_VALUE_TYPE(CASS_ERROR_LIB_INVALID_VALUE_TYPE).into())
+            CassError_::CASS_ERROR_LIB_NO_AVAILABLE_IO_THREAD => {
+                Err(ErrorKind::LIB_NO_AVAILABLE_IO_THREAD(CassError_::CASS_ERROR_LIB_NO_AVAILABLE_IO_THREAD).into())
             }
-            CASS_ERROR_LIB_REQUEST_TIMED_OUT => {
-                Err(ErrorKind::LIB_REQUEST_TIMED_OUT(CASS_ERROR_LIB_REQUEST_TIMED_OUT).into())
+            CassError_::CASS_ERROR_LIB_WRITE_ERROR => {
+                Err(ErrorKind::LIB_WRITE_ERROR(CassError_::CASS_ERROR_LIB_WRITE_ERROR).into())
             }
-            CASS_ERROR_LIB_UNABLE_TO_SET_KEYSPACE => {
-                Err(ErrorKind::LIB_UNABLE_TO_SET_KEYSPACE(CASS_ERROR_LIB_UNABLE_TO_SET_KEYSPACE).into())
+            CassError_::CASS_ERROR_LIB_NO_HOSTS_AVAILABLE => {
+                Err(ErrorKind::LIB_NO_HOSTS_AVAILABLE(CassError_::CASS_ERROR_LIB_NO_HOSTS_AVAILABLE).into())
             }
-            CASS_ERROR_LIB_CALLBACK_ALREADY_SET => {
-                Err(ErrorKind::LIB_CALLBACK_ALREADY_SET(CASS_ERROR_LIB_CALLBACK_ALREADY_SET).into())
+            CassError_::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS => {
+                Err(ErrorKind::LIB_INDEX_OUT_OF_BOUNDS(CassError_::CASS_ERROR_LIB_INDEX_OUT_OF_BOUNDS).into())
             }
-            CASS_ERROR_LIB_INVALID_STATEMENT_TYPE => {
-                Err(ErrorKind::LIB_INVALID_STATEMENT_TYPE(CASS_ERROR_LIB_INVALID_STATEMENT_TYPE).into())
+            CassError_::CASS_ERROR_LIB_INVALID_ITEM_COUNT => {
+                Err(ErrorKind::LIB_INVALID_ITEM_COUNT(CassError_::CASS_ERROR_LIB_INVALID_ITEM_COUNT).into())
             }
-            CASS_ERROR_LIB_NAME_DOES_NOT_EXIST => {
-                Err(ErrorKind::LIB_NAME_DOES_NOT_EXIST(CASS_ERROR_LIB_NAME_DOES_NOT_EXIST).into())
+            CassError_::CASS_ERROR_LIB_INVALID_VALUE_TYPE => {
+                Err(ErrorKind::LIB_INVALID_VALUE_TYPE(CassError_::CASS_ERROR_LIB_INVALID_VALUE_TYPE).into())
             }
-            CASS_ERROR_LIB_UNABLE_TO_DETERMINE_PROTOCOL => {
-                Err(ErrorKind::LIB_UNABLE_TO_DETERMINE_PROTOCOL(CASS_ERROR_LIB_UNABLE_TO_DETERMINE_PROTOCOL).into())
+            CassError_::CASS_ERROR_LIB_REQUEST_TIMED_OUT => {
+                Err(ErrorKind::LIB_REQUEST_TIMED_OUT(CassError_::CASS_ERROR_LIB_REQUEST_TIMED_OUT).into())
             }
-            CASS_ERROR_LIB_NULL_VALUE => Err(ErrorKind::LIB_NULL_VALUE(CASS_ERROR_LIB_NULL_VALUE).into()),
-            CASS_ERROR_LIB_NOT_IMPLEMENTED => {
-                Err(ErrorKind::LIB_NOT_IMPLEMENTED(CASS_ERROR_LIB_NOT_IMPLEMENTED).into())
+            CassError_::CASS_ERROR_LIB_UNABLE_TO_SET_KEYSPACE => {
+                Err(ErrorKind::LIB_UNABLE_TO_SET_KEYSPACE(CassError_::CASS_ERROR_LIB_UNABLE_TO_SET_KEYSPACE).into())
             }
-            CASS_ERROR_LIB_UNABLE_TO_CONNECT => {
-                Err(ErrorKind::LIB_UNABLE_TO_CONNECT(CASS_ERROR_LIB_UNABLE_TO_CONNECT).into())
+            CassError_::CASS_ERROR_LIB_CALLBACK_ALREADY_SET => {
+                Err(ErrorKind::LIB_CALLBACK_ALREADY_SET(CassError_::CASS_ERROR_LIB_CALLBACK_ALREADY_SET).into())
             }
-            CASS_ERROR_LIB_UNABLE_TO_CLOSE => {
-                Err(ErrorKind::LIB_UNABLE_TO_CLOSE(CASS_ERROR_LIB_UNABLE_TO_CLOSE).into())
+            CassError_::CASS_ERROR_LIB_INVALID_STATEMENT_TYPE => {
+                Err(ErrorKind::LIB_INVALID_STATEMENT_TYPE(CassError_::CASS_ERROR_LIB_INVALID_STATEMENT_TYPE).into())
             }
-            CASS_ERROR_LIB_NO_PAGING_STATE => {
-                Err(ErrorKind::LIB_NO_PAGING_STATE(CASS_ERROR_LIB_NO_PAGING_STATE).into())
+            CassError_::CASS_ERROR_LIB_NAME_DOES_NOT_EXIST => {
+                Err(ErrorKind::LIB_NAME_DOES_NOT_EXIST(CassError_::CASS_ERROR_LIB_NAME_DOES_NOT_EXIST).into())
             }
-            CASS_ERROR_LIB_PARAMETER_UNSET => {
-                Err(ErrorKind::LIB_PARAMETER_UNSET(CASS_ERROR_LIB_PARAMETER_UNSET).into())
+            CassError_::CASS_ERROR_LIB_UNABLE_TO_DETERMINE_PROTOCOL => {
+                Err(ErrorKind::LIB_UNABLE_TO_DETERMINE_PROTOCOL(CassError_::CASS_ERROR_LIB_UNABLE_TO_DETERMINE_PROTOCOL).into())
             }
-            CASS_ERROR_LIB_INVALID_ERROR_RESULT_TYPE => {
-                Err(ErrorKind::LIB_INVALID_ERROR_RESULT_TYPE(CASS_ERROR_LIB_INVALID_ERROR_RESULT_TYPE).into())
+            CassError_::CASS_ERROR_LIB_NULL_VALUE => {
+                Err(ErrorKind::LIB_NULL_VALUE(CassError_::CASS_ERROR_LIB_NULL_VALUE).into())
             }
-            CASS_ERROR_LIB_INVALID_FUTURE_TYPE => {
-                Err(ErrorKind::LIB_INVALID_FUTURE_TYPE(CASS_ERROR_LIB_INVALID_FUTURE_TYPE).into())
+            CassError_::CASS_ERROR_LIB_NOT_IMPLEMENTED => {
+                Err(ErrorKind::LIB_NOT_IMPLEMENTED(CassError_::CASS_ERROR_LIB_NOT_IMPLEMENTED).into())
             }
-            CASS_ERROR_LIB_INTERNAL_ERROR => Err(ErrorKind::LIB_INTERNAL_ERROR(CASS_ERROR_LIB_INTERNAL_ERROR).into()),
-            CASS_ERROR_LIB_INVALID_CUSTOM_TYPE => {
-                Err(ErrorKind::LIB_INVALID_CUSTOM_TYPE(CASS_ERROR_LIB_INVALID_CUSTOM_TYPE).into())
+            CassError_::CASS_ERROR_LIB_UNABLE_TO_CONNECT => {
+                Err(ErrorKind::LIB_UNABLE_TO_CONNECT(CassError_::CASS_ERROR_LIB_UNABLE_TO_CONNECT).into())
             }
-            CASS_ERROR_LIB_INVALID_DATA => Err(ErrorKind::LIB_INVALID_DATA(CASS_ERROR_LIB_INVALID_DATA).into()),
-            CASS_ERROR_LIB_NOT_ENOUGH_DATA => {
-                Err(ErrorKind::LIB_NOT_ENOUGH_DATA(CASS_ERROR_LIB_NOT_ENOUGH_DATA).into())
+            CassError_::CASS_ERROR_LIB_UNABLE_TO_CLOSE => {
+                Err(ErrorKind::LIB_UNABLE_TO_CLOSE(CassError_::CASS_ERROR_LIB_UNABLE_TO_CLOSE).into())
             }
-            CASS_ERROR_LIB_INVALID_STATE => Err(ErrorKind::LIB_INVALID_STATE(CASS_ERROR_LIB_INVALID_STATE).into()),
-            CASS_ERROR_LIB_NO_CUSTOM_PAYLOAD => {
-                Err(ErrorKind::LIB_NO_CUSTOM_PAYLOAD(CASS_ERROR_LIB_NO_CUSTOM_PAYLOAD).into())
+            CassError_::CASS_ERROR_LIB_NO_PAGING_STATE => {
+                Err(ErrorKind::LIB_NO_PAGING_STATE(CassError_::CASS_ERROR_LIB_NO_PAGING_STATE).into())
             }
-            CASS_ERROR_SERVER_SERVER_ERROR => {
-                Err(ErrorKind::SERVER_SERVER_ERROR(CASS_ERROR_SERVER_SERVER_ERROR).into())
+            CassError_::CASS_ERROR_LIB_PARAMETER_UNSET => {
+                Err(ErrorKind::LIB_PARAMETER_UNSET(CassError_::CASS_ERROR_LIB_PARAMETER_UNSET).into())
             }
-            CASS_ERROR_SERVER_PROTOCOL_ERROR => {
-                Err(ErrorKind::SERVER_PROTOCOL_ERROR(CASS_ERROR_SERVER_PROTOCOL_ERROR).into())
+            CassError_::CASS_ERROR_LIB_INVALID_ERROR_RESULT_TYPE => {
+                Err(ErrorKind::LIB_INVALID_ERROR_RESULT_TYPE(CassError_::CASS_ERROR_LIB_INVALID_ERROR_RESULT_TYPE)
+                    .into())
             }
-            CASS_ERROR_SERVER_BAD_CREDENTIALS => {
-                Err(ErrorKind::SERVER_BAD_CREDENTIALS(CASS_ERROR_SERVER_BAD_CREDENTIALS).into())
+            CassError_::CASS_ERROR_LIB_INVALID_FUTURE_TYPE => {
+                Err(ErrorKind::LIB_INVALID_FUTURE_TYPE(CassError_::CASS_ERROR_LIB_INVALID_FUTURE_TYPE).into())
             }
-            CASS_ERROR_SERVER_UNAVAILABLE => Err(ErrorKind::SERVER_UNAVAILABLE(CASS_ERROR_SERVER_UNAVAILABLE).into()),
-            CASS_ERROR_SERVER_OVERLOADED => Err(ErrorKind::SERVER_OVERLOADED(CASS_ERROR_SERVER_OVERLOADED).into()),
-            CASS_ERROR_SERVER_IS_BOOTSTRAPPING => {
-                Err(ErrorKind::SERVER_IS_BOOTSTRAPPING(CASS_ERROR_SERVER_IS_BOOTSTRAPPING).into())
+            CassError_::CASS_ERROR_LIB_INTERNAL_ERROR => {
+                Err(ErrorKind::LIB_INTERNAL_ERROR(CassError_::CASS_ERROR_LIB_INTERNAL_ERROR).into())
             }
-            CASS_ERROR_SERVER_TRUNCATE_ERROR => {
-                Err(ErrorKind::SERVER_TRUNCATE_ERROR(CASS_ERROR_SERVER_TRUNCATE_ERROR).into())
+            CassError_::CASS_ERROR_LIB_INVALID_CUSTOM_TYPE => {
+                Err(ErrorKind::LIB_INVALID_CUSTOM_TYPE(CassError_::CASS_ERROR_LIB_INVALID_CUSTOM_TYPE).into())
             }
-            CASS_ERROR_SERVER_WRITE_TIMEOUT => {
-                Err(ErrorKind::SERVER_WRITE_TIMEOUT(CASS_ERROR_SERVER_WRITE_TIMEOUT).into())
+            CassError_::CASS_ERROR_LIB_INVALID_DATA => {
+                Err(ErrorKind::LIB_INVALID_DATA(CassError_::CASS_ERROR_LIB_INVALID_DATA).into())
             }
-            CASS_ERROR_SERVER_READ_TIMEOUT => {
-                Err(ErrorKind::SERVER_READ_TIMEOUT(CASS_ERROR_SERVER_READ_TIMEOUT).into())
+            CassError_::CASS_ERROR_LIB_NOT_ENOUGH_DATA => {
+                Err(ErrorKind::LIB_NOT_ENOUGH_DATA(CassError_::CASS_ERROR_LIB_NOT_ENOUGH_DATA).into())
             }
-            CASS_ERROR_SERVER_READ_FAILURE => {
-                Err(ErrorKind::SERVER_READ_FAILURE(CASS_ERROR_SERVER_READ_FAILURE).into())
+            CassError_::CASS_ERROR_LIB_INVALID_STATE => {
+                Err(ErrorKind::LIB_INVALID_STATE(CassError_::CASS_ERROR_LIB_INVALID_STATE).into())
             }
-            CASS_ERROR_SERVER_FUNCTION_FAILURE => {
-                Err(ErrorKind::SERVER_FUNCTION_FAILURE(CASS_ERROR_SERVER_FUNCTION_FAILURE).into())
+            CassError_::CASS_ERROR_LIB_NO_CUSTOM_PAYLOAD => {
+                Err(ErrorKind::LIB_NO_CUSTOM_PAYLOAD(CassError_::CASS_ERROR_LIB_NO_CUSTOM_PAYLOAD).into())
             }
-            CASS_ERROR_SERVER_WRITE_FAILURE => {
-                Err(ErrorKind::SERVER_WRITE_FAILURE(CASS_ERROR_SERVER_WRITE_FAILURE).into())
+            CassError_::CASS_ERROR_SERVER_SERVER_ERROR => {
+                Err(ErrorKind::SERVER_SERVER_ERROR(CassError_::CASS_ERROR_SERVER_SERVER_ERROR).into())
             }
-            CASS_ERROR_SERVER_SYNTAX_ERROR => {
-                Err(ErrorKind::SERVER_SYNTAX_ERROR(CASS_ERROR_SERVER_WRITE_FAILURE).into())
+            CassError_::CASS_ERROR_SERVER_PROTOCOL_ERROR => {
+                Err(ErrorKind::SERVER_PROTOCOL_ERROR(CassError_::CASS_ERROR_SERVER_PROTOCOL_ERROR).into())
             }
-            CASS_ERROR_SERVER_UNAUTHORIZED => {
-                Err(ErrorKind::SERVER_UNAUTHORIZED(CASS_ERROR_SERVER_UNAUTHORIZED).into())
+            CassError_::CASS_ERROR_SERVER_BAD_CREDENTIALS => {
+                Err(ErrorKind::SERVER_BAD_CREDENTIALS(CassError_::CASS_ERROR_SERVER_BAD_CREDENTIALS).into())
             }
-            CASS_ERROR_SERVER_INVALID_QUERY => {
-                Err(ErrorKind::SERVER_INVALID_QUERY(CASS_ERROR_SERVER_INVALID_QUERY).into())
+            CassError_::CASS_ERROR_SERVER_UNAVAILABLE => {
+                Err(ErrorKind::SERVER_UNAVAILABLE(CassError_::CASS_ERROR_SERVER_UNAVAILABLE).into())
             }
-            CASS_ERROR_SERVER_CONFIG_ERROR => {
-                Err(ErrorKind::SERVER_CONFIG_ERROR(CASS_ERROR_SERVER_CONFIG_ERROR).into())
+            CassError_::CASS_ERROR_SERVER_OVERLOADED => {
+                Err(ErrorKind::SERVER_OVERLOADED(CassError_::CASS_ERROR_SERVER_OVERLOADED).into())
             }
-            CASS_ERROR_SERVER_ALREADY_EXISTS => {
-                Err(ErrorKind::SERVER_ALREADY_EXISTS(CASS_ERROR_SERVER_ALREADY_EXISTS).into())
+            CassError_::CASS_ERROR_SERVER_IS_BOOTSTRAPPING => {
+                Err(ErrorKind::SERVER_IS_BOOTSTRAPPING(CassError_::CASS_ERROR_SERVER_IS_BOOTSTRAPPING).into())
             }
-            CASS_ERROR_SERVER_UNPREPARED => Err(ErrorKind::SERVER_UNPREPARED(CASS_ERROR_SERVER_UNPREPARED).into()),
-            CASS_ERROR_SSL_INVALID_CERT => Err(ErrorKind::SSL_INVALID_CERT(CASS_ERROR_SSL_INVALID_CERT).into()),
-            CASS_ERROR_SSL_INVALID_PRIVATE_KEY => {
-                Err(ErrorKind::SSL_INVALID_PRIVATE_KEY(CASS_ERROR_SSL_INVALID_PRIVATE_KEY).into())
+            CassError_::CASS_ERROR_SERVER_TRUNCATE_ERROR => {
+                Err(ErrorKind::SERVER_TRUNCATE_ERROR(CassError_::CASS_ERROR_SERVER_TRUNCATE_ERROR).into())
             }
-            CASS_ERROR_SSL_NO_PEER_CERT => Err(ErrorKind::SSL_NO_PEER_CERT(CASS_ERROR_SSL_NO_PEER_CERT).into()),
-            CASS_ERROR_SSL_INVALID_PEER_CERT => {
-                Err(ErrorKind::SSL_INVALID_PEER_CERT(CASS_ERROR_SSL_INVALID_PEER_CERT).into())
+            CassError_::CASS_ERROR_SERVER_WRITE_TIMEOUT => {
+                Err(ErrorKind::SERVER_WRITE_TIMEOUT(CassError_::CASS_ERROR_SERVER_WRITE_TIMEOUT).into())
             }
-            CASS_ERROR_SSL_IDENTITY_MISMATCH => {
-                Err(ErrorKind::SSL_IDENTITY_MISMATCH(CASS_ERROR_SSL_IDENTITY_MISMATCH).into())
+            CassError_::CASS_ERROR_SERVER_READ_TIMEOUT => {
+                Err(ErrorKind::SERVER_READ_TIMEOUT(CassError_::CASS_ERROR_SERVER_READ_TIMEOUT).into())
             }
-            CASS_ERROR_SSL_PROTOCOL_ERROR => Err(ErrorKind::SSL_PROTOCOL_ERROR(CASS_ERROR_SSL_PROTOCOL_ERROR).into()),
-            CASS_ERROR_LAST_ENTRY => Err(ErrorKind::LAST_ENTRY(CASS_ERROR_LAST_ENTRY).into()),
+            CassError_::CASS_ERROR_SERVER_READ_FAILURE => {
+                Err(ErrorKind::SERVER_READ_FAILURE(CassError_::CASS_ERROR_SERVER_READ_FAILURE).into())
+            }
+            CassError_::CASS_ERROR_SERVER_FUNCTION_FAILURE => {
+                Err(ErrorKind::SERVER_FUNCTION_FAILURE(CassError_::CASS_ERROR_SERVER_FUNCTION_FAILURE).into())
+            }
+            CassError_::CASS_ERROR_SERVER_WRITE_FAILURE => {
+                Err(ErrorKind::SERVER_WRITE_FAILURE(CassError_::CASS_ERROR_SERVER_WRITE_FAILURE).into())
+            }
+            CassError_::CASS_ERROR_SERVER_SYNTAX_ERROR => {
+                Err(ErrorKind::SERVER_SYNTAX_ERROR(CassError_::CASS_ERROR_SERVER_WRITE_FAILURE).into())
+            }
+            CassError_::CASS_ERROR_SERVER_UNAUTHORIZED => {
+                Err(ErrorKind::SERVER_UNAUTHORIZED(CassError_::CASS_ERROR_SERVER_UNAUTHORIZED).into())
+            }
+            CassError_::CASS_ERROR_SERVER_INVALID_QUERY => {
+                Err(ErrorKind::SERVER_INVALID_QUERY(CassError_::CASS_ERROR_SERVER_INVALID_QUERY).into())
+            }
+            CassError_::CASS_ERROR_SERVER_CONFIG_ERROR => {
+                Err(ErrorKind::SERVER_CONFIG_ERROR(CassError_::CASS_ERROR_SERVER_CONFIG_ERROR).into())
+            }
+            CassError_::CASS_ERROR_SERVER_ALREADY_EXISTS => {
+                Err(ErrorKind::SERVER_ALREADY_EXISTS(CassError_::CASS_ERROR_SERVER_ALREADY_EXISTS).into())
+            }
+            CassError_::CASS_ERROR_SERVER_UNPREPARED => {
+                Err(ErrorKind::SERVER_UNPREPARED(CassError_::CASS_ERROR_SERVER_UNPREPARED).into())
+            }
+            CassError_::CASS_ERROR_SSL_INVALID_CERT => {
+                Err(ErrorKind::SSL_INVALID_CERT(CassError_::CASS_ERROR_SSL_INVALID_CERT).into())
+            }
+            CassError_::CASS_ERROR_SSL_INVALID_PRIVATE_KEY => {
+                Err(ErrorKind::SSL_INVALID_PRIVATE_KEY(CassError_::CASS_ERROR_SSL_INVALID_PRIVATE_KEY).into())
+            }
+            CassError_::CASS_ERROR_SSL_NO_PEER_CERT => {
+                Err(ErrorKind::SSL_NO_PEER_CERT(CassError_::CASS_ERROR_SSL_NO_PEER_CERT).into())
+            }
+            CassError_::CASS_ERROR_SSL_INVALID_PEER_CERT => {
+                Err(ErrorKind::SSL_INVALID_PEER_CERT(CassError_::CASS_ERROR_SSL_INVALID_PEER_CERT).into())
+            }
+            CassError_::CASS_ERROR_SSL_IDENTITY_MISMATCH => {
+                Err(ErrorKind::SSL_IDENTITY_MISMATCH(CassError_::CASS_ERROR_SSL_IDENTITY_MISMATCH).into())
+            }
+            CassError_::CASS_ERROR_SSL_PROTOCOL_ERROR => {
+                Err(ErrorKind::SSL_PROTOCOL_ERROR(CassError_::CASS_ERROR_SSL_PROTOCOL_ERROR).into())
+            }
+            CassError_::CASS_ERROR_LAST_ENTRY => Err(ErrorKind::LAST_ENTRY(CassError_::CASS_ERROR_LAST_ENTRY).into()),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@ pub use cassandra::CassValueType_::*;
 pub use cassandra::CassCollectionType_::{CASS_COLLECTION_TYPE_SET, CASS_COLLECTION_TYPE_LIST, CASS_COLLECTION_TYPE_MAP};
 
 // pub use cassandra::ffi_util::raw2utf8;
-pub use cassandra::*;
 
 mod cassandra;
 pub mod ffi_util;


### PR DESCRIPTION
Removed double imports and inserted the full type of error enum variants. Examples are still mostly broken.

